### PR TITLE
[#10] s3로직 추가

### DIFF
--- a/backend/src/main/java/com/inha/borrow/backend/controller/SignUpRequestController.java
+++ b/backend/src/main/java/com/inha/borrow/backend/controller/SignUpRequestController.java
@@ -1,11 +1,17 @@
 package com.inha.borrow.backend.controller;
 
-import com.inha.borrow.backend.model.dto.EvaluationRequest;
-import com.inha.borrow.backend.model.dto.SignUpForm;
-import com.inha.borrow.backend.model.response.ApiResponse;
+import com.inha.borrow.backend.cache.SignUpSessionCache;
+import com.inha.borrow.backend.model.dto.response.ApiResponse;
+import com.inha.borrow.backend.model.dto.signUpRequest.EvaluationRequestDto;
+import com.inha.borrow.backend.model.dto.user.borrower.SignUpFormDto;
+import com.inha.borrow.backend.model.entity.SignUpForm;
 import com.inha.borrow.backend.service.S3Service;
 import com.inha.borrow.backend.service.SignUpRequestService;
-import lombok.AllArgsConstructor;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -13,75 +19,107 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
- *signUpRequest를 관리하는 컨트롤러
+ * signUpRequest를 관리하는 컨트롤러
  * 회원가입, 정보 수정, 요청 삭제등을 담당합니다.
+ * 
  * @author 형민재
  */
 
 @RestController
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class SignUpRequestController {
     private final S3Service s3Service;
     private final SignUpRequestService signUpRequestService;
+    private final SignUpSessionCache signUpSessionCache;
+
+    @Value("${app.cloud.aws.s3.dir.name}")
+    private String STUDENT_COUNCIL_FEE_PATH;
+    @Value("${app.cloud.aws.s3.dir.name}")
+    private String STUDENT_IDENTIFICATION_PATH;
 
     /**
-     *회원가입을 진행하는 메서드
-     * @param signUpForm
-     * @param studentCouncilFdd
+     * 회원가입을 진행하는 메서드
+     * 
+     * @param signUpFormDto
+     * @param studentCouncilFee
      * @param studentIdentification
      * @return 201 생성성공
      * @author 형민재
      */
-    @PostMapping(value = "/borrowers/signup-requests",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<SignUpForm>> signUpBorrower(@RequestPart SignUpForm signUpForm, @RequestPart MultipartFile studentIdentification, @RequestPart MultipartFile studentCouncilFdd) {
-        String idCard = s3Service.uploadFile(studentIdentification, "student-identification");
-        String councilFdd = s3Service.uploadFile(studentCouncilFdd, "student-council-fdd");
-        signUpForm.setIdentityPhoto(idCard);
-        signUpForm.setStudentCouncilFeePhoto(councilFdd);
+    @PostMapping(value = "/borrowers/signup-requests", consumes = { MediaType.MULTIPART_FORM_DATA_VALUE,
+            MediaType.APPLICATION_JSON_VALUE })
+    public ResponseEntity<ApiResponse<SignUpForm>> signUpBorrower(
+            @Valid @RequestPart("signUpFormDto") SignUpFormDto signUpFormDto,
+            @RequestPart("student-identification") MultipartFile studentIdentification,
+            @RequestPart("student-council-fee") MultipartFile studentCouncilFee) {
+        String idCard = s3Service.uploadFile(studentIdentification, STUDENT_IDENTIFICATION_PATH, signUpFormDto.getId());
+        String councilFee = s3Service.uploadFile(studentCouncilFee, STUDENT_COUNCIL_FEE_PATH, signUpFormDto.getId());
+        SignUpForm signUpForm = signUpFormDto.getSignUpForm(idCard, councilFee);
         SignUpForm result = signUpRequestService.saveSignUpRequest(signUpForm);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>(true, result));
-
     }
+
     /**
-     *회원가입 요청을 승인하는 메서드
-     * @param evaluationRequest
+     * 회원가입 요청을 승인하는 메서드
+     * 
+     * @param EvaluationRequestDto
      * @param id
      * @return 200 생성성공
      * @author 형민재
      */
     @PutMapping("/borrowers/signup-request/{signup-request-id}")
-    public ResponseEntity<ApiResponse<Void>> evaluateRequest(@RequestBody EvaluationRequest evaluationRequest, @PathVariable("signup-request-id") String id) {
-        signUpRequestService.updateStateAndCreateBorrower(evaluationRequest, id);
+    public ResponseEntity<ApiResponse<Void>> evaluateRequest(
+            @Valid @RequestBody EvaluationRequestDto EvaluationRequestDto,
+            @PathVariable("signup-request-id") String id) {
+        signUpRequestService.updateStateAndCreateBorrower(EvaluationRequestDto, id);
         return ResponseEntity.ok().build();
     }
 
     /**
-     *회원가입 요청을 수정하는 메서드
+     * 회원가입 요청을 수정하는 메서드
+     * 
      * @param signUpForm
      * @param id
-     * @param studentCouncilFdd
+     * @param studentCouncilFee
      * @param studentIdentification
      * @return 200 생성성공
      * @author 형민재
      */
-    @PutMapping(value = "/signup-requests/{signup-request-id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<Void>> rewriteRequest(@PathVariable("signup-request-id") String id, @RequestPart SignUpForm signUpForm,@RequestPart MultipartFile studentIdentification, @RequestPart MultipartFile studentCouncilFdd) {
-        String idCard = s3Service.uploadFile(studentIdentification, "student-identification");
-        String councilFdd = s3Service.uploadFile(studentCouncilFdd, "student-council-fdd");
-        signUpForm.setIdentityPhoto(idCard);
-        signUpForm.setStudentCouncilFeePhoto(councilFdd);
-        signUpRequestService.patchSignUpRequest(signUpForm, id);
+    @PutMapping(value = "/signup-requests/{signup-request-id}", consumes = { MediaType.MULTIPART_FORM_DATA_VALUE,
+            MediaType.APPLICATION_JSON_VALUE })
+    public ResponseEntity<ApiResponse<Void>> rewriteRequest(@PathVariable("signup-request-id") String id,
+            @RequestPart String originPassword,
+            @RequestPart SignUpForm signUpForm,
+            @RequestPart(value = "student-identification", required = false) MultipartFile studentIdentification,
+            @RequestPart(value = "student-council-fee", required = false) MultipartFile studentCouncilFee) {
+        signUpRequestService.findById(id);
+        signUpSessionCache.get(id);
+
+        if(studentCouncilFee!=null && !studentCouncilFee.isEmpty()) {
+            String councilFee = s3Service.uploadFile(studentCouncilFee,
+                    "student-council-fee", id);
+            signUpForm.setStudentCouncilFeePhoto(councilFee);
+        }
+        if(studentIdentification!=null && !studentIdentification.isEmpty()) {
+            String idCard = s3Service.uploadFile(studentIdentification,
+                    "student-identification", id);
+            signUpForm.setIdentityPhoto(idCard);
+        }
+        signUpRequestService.patchSignUpRequest(signUpForm,id,originPassword);
         return ResponseEntity.ok().build();
     }
+
     /**
-     *회원가입 요청을 삭제하는 메서드
+     * 회원가입 요청을 삭제하는 메서드
+     * 
      * @param id
      * @return 204 요청성공
      * @author 형민재
      */
 
     @DeleteMapping("/signup-request/{signup-request-id}")
-    public ResponseEntity<Void> deleteRequest(@PathVariable("signup-request-id") String id, @RequestBody String password) {
+    public ResponseEntity<Void> deleteRequest(@PathVariable("signup-request-id") String id,
+            @RequestBody String password) {
         signUpRequestService.deleteSignUpRequest(id, password);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 

--- a/backend/src/main/java/com/inha/borrow/backend/model/dto/user/borrower/SignUpFormDto.java
+++ b/backend/src/main/java/com/inha/borrow/backend/model/dto/user/borrower/SignUpFormDto.java
@@ -1,0 +1,33 @@
+package com.inha.borrow.backend.model.dto.user.borrower;
+
+import com.inha.borrow.backend.model.entity.SignUpForm;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SignUpFormDto {
+    @NotBlank
+    private String id;
+    @NotBlank
+    private String password;
+    @NotBlank
+    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")
+    private String email;
+    @NotBlank
+    private String name;
+    @NotBlank
+    private String phoneNumber;
+    @NotBlank
+    private String accountNumber;
+
+    public SignUpForm getSignUpForm(String studentIdentification, String studentCouncilFee) {
+        return new SignUpForm(id, password, email, name, phoneNumber, studentIdentification, studentCouncilFee,
+                accountNumber);
+    }
+}

--- a/backend/src/main/java/com/inha/borrow/backend/service/S3Service.java
+++ b/backend/src/main/java/com/inha/borrow/backend/service/S3Service.java
@@ -4,37 +4,53 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.UUID;
 
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
+@Slf4j
 public class S3Service {
     private final AmazonS3 amazonS3;
 
-    @Value("${cloud.aws.s3.bucket}")
+    @Value("${app.cloud.aws.s3.bucket}")
     private String bucket;
 
     /**
      *
      * @param multipartFile
-     * @param url
+     * @param id
+     * @param folder
      * @return 사진이 저장된 url
      * @author 형민재
      */
-    public String uploadFile(MultipartFile multipartFile, String url){
-        String fileName = url + "/" + UUID.randomUUID() + "_" + multipartFile.getOriginalFilename();
+    public String uploadFile(MultipartFile multipartFile, String folder, String id) {
+        String originalFilename = multipartFile.getOriginalFilename();
+        String extension = "";
+        if (originalFilename != null && originalFilename.contains(".")) {
+            extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        }
+        String fileName = folder + "/" + id + extension;
         ObjectMetadata objMeta = new ObjectMetadata();
         objMeta.setContentLength(multipartFile.getSize());
+        objMeta.setContentType(multipartFile.getContentType());
         try {
             amazonS3.putObject(bucket, fileName, multipartFile.getInputStream(), objMeta);
         } catch (IOException e) {
             throw new AmazonS3Exception("s3 업로드 실패");
         }
-        return amazonS3.getUrl(bucket,fileName).toString();
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+    public void deleteFile(String bucket,String folder, String id){
+        String key = folder+"/"+id;
+        amazonS3.deleteObject(bucket,key);
+    }
+    public void deleteAllFile(String bucket ,String id){
+        amazonS3.deleteObject(bucket,"student-council-fee/"+id);
+        amazonS3.deleteObject(bucket,"student-identification/"+id);
     }
 }


### PR DESCRIPTION
S3Service 삭제 메서드 추가
saveSignUpRequest s3 transactional 추가
updateStateAndCreateBorrower s3 삭제 추가
patchSignUpRequest originPassword 인자 추가

rewriteRequest
-세션확인
-아이디확인
-파일이 하나만 들어와도 patch 가능하게 로직 추가

의문
사용자가 id를 수정하면 수정 전 아이디 경로로 저장한 s3는 어떻게 처리?