### PR TITLE
[#15] 부서 생성, 수정, 삭제, 수정 API 개발

### DIFF
--- a/backend/src/main/java/com/inha/borrow/backend/config/AuthConfig.java
+++ b/backend/src/main/java/com/inha/borrow/backend/config/AuthConfig.java
@@ -115,6 +115,15 @@ public class AuthConfig {
 							// 회원가입 신청, 삭제, 수정하는 경로는 누구나 접근 가능하다.(서비스단에서 인증 수행)
 							.requestMatchers("/borrowers/signup-requests/*")
 							.permitAll()
+							//
+							// /divisions 관련 인증설정
+							// 부서 목록을 가져오는 경로는 국장권한 이상만 접근가능하다
+							.requestMatchers(HttpMethod.GET, "/divisions")
+							.hasAuthority(Role.DIVISION_HEAD.name())
+							// 부서 정보와 관련된 등로그 수정, 삭제 관련 경로는 학생회장만 접근가능하다
+							.requestMatchers("/divisions")
+							.hasAuthority(Role.PRESIDENT.name())
+							// 이외의 경로는 무조건 인증 필요함
 							.anyRequest().authenticated();
 
 				})

--- a/backend/src/main/java/com/inha/borrow/backend/controller/DivisionController.java
+++ b/backend/src/main/java/com/inha/borrow/backend/controller/DivisionController.java
@@ -1,0 +1,54 @@
+package com.inha.borrow.backend.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.inha.borrow.backend.model.dto.division.DivisionDto;
+import com.inha.borrow.backend.model.dto.response.ApiResponse;
+import com.inha.borrow.backend.model.entity.Division;
+import com.inha.borrow.backend.service.DivisionService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/divisions")
+public class DivisionController {
+    private final DivisionService divisionService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<Division>>> findAllDivisions() {
+        List<Division> divisions = divisionService.findAllDivisions();
+        ApiResponse<List<Division>> response = new ApiResponse<>(true, divisions);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Division>> saveDivision(@RequestBody DivisionDto divisionDto) {
+        Division savedDivision = divisionService.saveDivision(divisionDto);
+        ApiResponse<Division> response = new ApiResponse<Division>(true, savedDivision);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PatchMapping
+    public ResponseEntity<ApiResponse<Void>> updateDivision(@RequestBody DivisionDto divisionDto) {
+        divisionService.updateDivision(divisionDto);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<Void>> deleteDivision(@RequestBody DivisionDto divisionDto) {
+        divisionService.deleteDivision(divisionDto);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/inha/borrow/backend/controller/DivisionController.java
+++ b/backend/src/main/java/com/inha/borrow/backend/controller/DivisionController.java
@@ -12,6 +12,7 @@ import com.inha.borrow.backend.model.dto.response.ApiResponse;
 import com.inha.borrow.backend.model.entity.Division;
 import com.inha.borrow.backend.service.DivisionService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -34,20 +35,20 @@ public class DivisionController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<Division>> saveDivision(@RequestBody DivisionDto divisionDto) {
+    public ResponseEntity<ApiResponse<Division>> saveDivision(@RequestBody @Valid DivisionDto divisionDto) {
         Division savedDivision = divisionService.saveDivision(divisionDto);
         ApiResponse<Division> response = new ApiResponse<Division>(true, savedDivision);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PatchMapping
-    public ResponseEntity<ApiResponse<Void>> updateDivision(@RequestBody DivisionDto divisionDto) {
+    public ResponseEntity<ApiResponse<Void>> updateDivision(@RequestBody @Valid DivisionDto divisionDto) {
         divisionService.updateDivision(divisionDto);
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping
-    public ResponseEntity<ApiResponse<Void>> deleteDivision(@RequestBody DivisionDto divisionDto) {
+    public ResponseEntity<ApiResponse<Void>> deleteDivision(@RequestBody @Valid DivisionDto divisionDto) {
         divisionService.deleteDivision(divisionDto);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/inha/borrow/backend/model/dto/division/DivisionDto.java
+++ b/backend/src/main/java/com/inha/borrow/backend/model/dto/division/DivisionDto.java
@@ -2,6 +2,7 @@ package com.inha.borrow.backend.model.dto.division;
 
 import com.inha.borrow.backend.model.entity.Division;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,7 +11,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DivisionDto {
+    @NotBlank
     private String code;
+    @NotBlank
     private String name;
 
     public Division getDivision() {

--- a/backend/src/main/java/com/inha/borrow/backend/model/dto/division/DivisionDto.java
+++ b/backend/src/main/java/com/inha/borrow/backend/model/dto/division/DivisionDto.java
@@ -1,0 +1,19 @@
+package com.inha.borrow.backend.model.dto.division;
+
+import com.inha.borrow.backend.model.entity.Division;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DivisionDto {
+    private String code;
+    private String name;
+
+    public Division getDivision() {
+        return new Division(this.code, this.name);
+    }
+}

--- a/backend/src/main/java/com/inha/borrow/backend/model/dto/division/DivisionDto.java
+++ b/backend/src/main/java/com/inha/borrow/backend/model/dto/division/DivisionDto.java
@@ -11,9 +11,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DivisionDto {
-    @NotBlank
+    @NotBlank(message = "부서코드는 필수입니다.")
     private String code;
-    @NotBlank
+    @NotBlank(message = "부서명은 필수입니다.")
     private String name;
 
     public Division getDivision() {

--- a/backend/src/main/java/com/inha/borrow/backend/model/entity/Division.java
+++ b/backend/src/main/java/com/inha/borrow/backend/model/entity/Division.java
@@ -1,0 +1,13 @@
+package com.inha.borrow.backend.model.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class Division {
+    private final String code;
+    private final String name;
+}

--- a/backend/src/main/java/com/inha/borrow/backend/repository/DivisionRepository.java
+++ b/backend/src/main/java/com/inha/borrow/backend/repository/DivisionRepository.java
@@ -1,0 +1,83 @@
+package com.inha.borrow.backend.repository;
+
+import java.util.List;
+
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.inha.borrow.backend.enums.ApiErrorCode;
+import com.inha.borrow.backend.model.dto.division.DivisionDto;
+import com.inha.borrow.backend.model.entity.Division;
+import com.inha.borrow.backend.model.exception.InvalidValueException;
+import com.inha.borrow.backend.model.exception.ResourceNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Division 객체와 관련된 DB작업을 하는 클래스
+ */
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class DivisionRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * Division 목록을 조회하는 메서드
+     */
+    public List<Division> findAllDivisions() {
+        String sql = "SELECT * FROM division WHERE is_delete = false;";
+        return jdbcTemplate.query(sql, (rs, num) -> {
+            String name = rs.getString("name");
+            String code = rs.getString("code");
+            return new Division(code, name);
+        });
+    }
+
+    /**
+     * Division객체를 DB에 저장하는 메서드
+     */
+    public Division saveDivision(DivisionDto divisionDto) {
+        String sql = "INSERT INTO division(code, name) VALUE(?, ?);";
+        try {
+            jdbcTemplate.update(sql,
+                    divisionDto.getCode(),
+                    divisionDto.getName());
+        } catch (DuplicateKeyException e) {
+            ApiErrorCode apiErrorCode = ApiErrorCode.INVALID_VALUE;
+            apiErrorCode.setMessage("이미 존재하는 부서 코드입니다.");
+            throw new InvalidValueException(apiErrorCode.name(), apiErrorCode.getMessage());
+        }
+        return divisionDto.getDivision();
+    }
+
+    /**
+     * Division이름을 수정하는 메서드
+     */
+    public void updateDivision(DivisionDto divisionDto) {
+        String sql = "UPDATE division SET name = ? WHERE code = ?;";
+
+        int affected = jdbcTemplate.update(sql, divisionDto.getName(), divisionDto.getCode());
+        if (affected == 0) {
+            ApiErrorCode errorCode = ApiErrorCode.NOT_FOUND;
+            errorCode.setMessage("수정하려는 부서가 존재하지 않습니다.");
+            throw new ResourceNotFoundException(errorCode.name(), errorCode.getMessage());
+        }
+    }
+
+    /**
+     * Division하나를 삭제하는 메서드
+     */
+    public void deleteDivision(DivisionDto divisionDto) {
+        String sql = "UPDATE division SET is_delete = true WHERE code = ?;";
+
+        int affected = jdbcTemplate.update(sql, divisionDto.getCode());
+        if (affected == 0) {
+            ApiErrorCode errorCode = ApiErrorCode.NOT_FOUND;
+            errorCode.setMessage("삭제하려는 부서가 존재하지 않습니다.");
+            throw new ResourceNotFoundException(errorCode.name(), errorCode.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/inha/borrow/backend/repository/ItemRepository.java
+++ b/backend/src/main/java/com/inha/borrow/backend/repository/ItemRepository.java
@@ -78,7 +78,7 @@ public class ItemRepository {
      * @author 장지왕
      */
     public List<Item> findAll() {
-        String sql = "SELECT * FROM item ORDER BY id DESC;";
+        String sql = "SELECT * FROM item WHERE state != 'DELETED' ORDER BY id DESC;";
         return jdbcTemplate.query(sql, itemRowMapper);
     }
 

--- a/backend/src/main/java/com/inha/borrow/backend/service/DivisionService.java
+++ b/backend/src/main/java/com/inha/borrow/backend/service/DivisionService.java
@@ -1,0 +1,34 @@
+package com.inha.borrow.backend.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.inha.borrow.backend.model.dto.division.DivisionDto;
+import com.inha.borrow.backend.model.entity.Division;
+import com.inha.borrow.backend.repository.DivisionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DivisionService {
+    private final DivisionRepository divisionRepository;
+
+    public List<Division> findAllDivisions() {
+        return divisionRepository.findAllDivisions();
+    }
+
+    public Division saveDivision(DivisionDto divisionDto) {
+        return divisionRepository.saveDivision(divisionDto);
+    }
+
+    public void updateDivision(DivisionDto divisionDto) {
+        divisionRepository.updateDivision(divisionDto);
+    }
+
+    public void deleteDivision(DivisionDto divisionDto) {
+        divisionRepository.deleteDivision(divisionDto);
+    }
+
+}

--- a/backend/src/main/resources/templates/table-setting.sql
+++ b/backend/src/main/resources/templates/table-setting.sql
@@ -4,19 +4,21 @@ use inha_item_borrow_service;
 
 
 CREATE TABLE admin_role(
-    id int auto_increment primary key,
-    role varchar(15) unique
+    role varchar(15) primary key,
 );
 
 CREATE TABLE division(
-    id int auto_increment primary key,
-    role varchar(20) unique
+    code varchar(20) primary key,
+    name varchar(20) NOT NULL,
+    is_delete boolean default false
 );
 
 INSERT INTO admin_role(role) VALUE("PRESIDENT");
 INSERT INTO admin_role(role) VALUE("VICE_PRESIDENT");
 INSERT INTO admin_role(role) VALUE("DIVISION_HEAD");
 INSERT INTO admin_role(role) VALUE("DIVISION_MEMBER");
+
+INSERT INTO division(code, name) VALUE("TEST", "테스트 부서")
 
 -- admin table 생성
 CREATE TABLE admin(

--- a/backend/src/test/java/com/inha/borrow/backend/controller/BorrowerAuthControllerTest.java
+++ b/backend/src/test/java/com/inha/borrow/backend/controller/BorrowerAuthControllerTest.java
@@ -1,4 +1,4 @@
-package com.inha.borrow.backend.controller.unit;
+package com.inha.borrow.backend.controller;
 
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -21,7 +21,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.inha.borrow.backend.controller.BorrowerAuthController;
 import com.inha.borrow.backend.enums.ApiErrorCode;
 import com.inha.borrow.backend.model.dto.auth.PasswordVerifyRequestDto;
 import com.inha.borrow.backend.model.dto.auth.SMSCodeRequestDto;

--- a/backend/src/test/java/com/inha/borrow/backend/controller/BorrowerControllerTest.java
+++ b/backend/src/test/java/com/inha/borrow/backend/controller/BorrowerControllerTest.java
@@ -1,4 +1,4 @@
-package com.inha.borrow.backend.controller.unit;
+package com.inha.borrow.backend.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.inha.borrow.backend.config.AuthConfig;
 import com.inha.borrow.backend.config.auth.admin.AdminAuthenticationProvider;
 import com.inha.borrow.backend.config.auth.borrowers.BorrowerAuthenticationProvider;
-import com.inha.borrow.backend.controller.BorrowerController;
 import com.inha.borrow.backend.forAuthTest.borrower.WithMockBorrower;
 import com.inha.borrow.backend.model.dto.user.PatchPasswordDto;
 import com.inha.borrow.backend.service.BorrowerService;

--- a/backend/src/test/java/com/inha/borrow/backend/controller/DivisionControllerTest.java
+++ b/backend/src/test/java/com/inha/borrow/backend/controller/DivisionControllerTest.java
@@ -1,0 +1,259 @@
+package com.inha.borrow.backend.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.apache.http.entity.ContentType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.inha.borrow.backend.config.AuthConfig;
+import com.inha.borrow.backend.config.auth.admin.AdminAuthenticationProvider;
+import com.inha.borrow.backend.config.auth.borrowers.BorrowerAuthenticationProvider;
+import com.inha.borrow.backend.enums.ApiErrorCode;
+import com.inha.borrow.backend.model.dto.division.DivisionDto;
+import com.inha.borrow.backend.model.dto.response.ApiResponse;
+import com.inha.borrow.backend.model.dto.response.ErrorResponse;
+import com.inha.borrow.backend.model.entity.Division;
+import com.inha.borrow.backend.service.DivisionService;
+
+@WebMvcTest(controllers = DivisionController.class)
+@Import(AuthConfig.class)
+public class DivisionControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    DivisionService divisionService;
+
+    @MockitoBean
+    AdminAuthenticationProvider mockAdminAuthenticationProvider;
+
+    @MockitoBean
+    BorrowerAuthenticationProvider mockAuthenticationProvider;
+
+    @Test
+    @DisplayName("부서목록 조회 테스트(성공-국장 이상만 접근 가능)")
+    @WithMockUser(authorities = "DIVISION_HEAD")
+    void findAllDivisionsSuccessTest() throws Exception {
+        // given
+        List<Division> expectedResult = List.of(new Division("TEST", "테스트"));
+        ApiResponse<List<Division>> expectedResponse = new ApiResponse<>(true, expectedResult);
+        when(divisionService.findAllDivisions()).thenReturn(expectedResult);
+        // when
+        // then
+        mockMvc.perform(get("/divisions"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(expectedResponse)));
+    }
+
+    @Test
+    @DisplayName("부서목록 조회 테스트(실패-국장 이상만 접근 가능)")
+    @WithMockUser(authorities = "DIVISION_MEMBER")
+    void findAllDivisionsFailForAuthorityTest() throws Exception {
+        // given
+        List<Division> expected = List.of(new Division("TEST", "테스트"));
+        when(divisionService.findAllDivisions()).thenReturn(expected);
+        // when
+        // then
+        mockMvc.perform(get("/divisions"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("부서목록 조회 테스트(실패-로그인 안 한 사용자)")
+    @WithAnonymousUser
+    void findAllDivisionsFailForNoLoginTest() throws Exception {
+        // given
+        List<Division> expected = List.of(new Division("TEST", "테스트"));
+        when(divisionService.findAllDivisions()).thenReturn(expected);
+        // when
+        // then
+        mockMvc.perform(get("/divisions"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("부서 저장 테스트(성공-학생회장만 접근 가능)")
+    @WithMockUser(authorities = "PRESIDENT")
+    void saveDivisionSuccessTest() throws Exception {
+        // given
+        DivisionDto divisionDto = new DivisionDto("TEST", "테스트");
+        Division expectedResult = new Division("TEST", "테스트");
+        ApiResponse<Division> expectedResponse = new ApiResponse<Division>(true, expectedResult);
+        when(divisionService.saveDivision(divisionDto)).thenReturn(expectedResult);
+        // when
+        // then
+        mockMvc.perform(post("/divisions")
+                .content(objectMapper.writeValueAsString(divisionDto))
+                .contentType(ContentType.APPLICATION_JSON.getMimeType()))
+                .andExpect(status().isCreated())
+                .andExpect(content().json(objectMapper.writeValueAsString(expectedResponse)));
+    }
+
+    @Test
+    @DisplayName("부서 저장 테스트(실패-학생회장만 접근 가능)")
+    @WithMockUser(authorities = "VICE_PRESIDENT")
+    void saveDivisionFailForAuthorityTest() throws Exception {
+        // given
+        DivisionDto divisionDto = new DivisionDto("TEST", "테스트");
+        Division expectedResult = new Division("TEST", "테스트");
+        when(divisionService.saveDivision(divisionDto)).thenReturn(expectedResult);
+        // when
+        // then
+        mockMvc.perform(post("/divisions")
+                .content(objectMapper.writeValueAsString(divisionDto))
+                .contentType(ContentType.APPLICATION_JSON.getMimeType()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("부서 저장(실패-로그인 안한 사용자)")
+    @WithAnonymousUser
+    void saveDivisionFailForNotLoginTest() throws Exception {
+        // given
+        DivisionDto divisionDto = new DivisionDto("TEST", "테스트");
+        Division expectedResult = new Division("TEST", "테스트");
+        when(divisionService.saveDivision(divisionDto)).thenReturn(expectedResult);
+        // when
+        // then
+        mockMvc.perform(post("/divisions")
+                .content(objectMapper.writeValueAsString(divisionDto))
+                .contentType(ContentType.APPLICATION_JSON.getMimeType()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // 똑같은 DTO 사용해서 나머지 메서드(PATCH, DELETE)도 이거로 대체
+    @ParameterizedTest
+    @DisplayName("부서 저장 테스트(실패-허용되지 않는 값)")
+    @CsvSource({
+            "' ', 테스트 부서, 부서코드는 필수입니다.",
+            "TEST, ' ', 부서명은 필수입니다."
+    })
+    @WithMockUser(authorities = "PRESIDENT")
+    void saveDivisionFailForInvalidValueTest(String code, String name, String errorMsg) throws Exception {
+        // given
+        DivisionDto divisionDto = new DivisionDto(code, name);
+        when(divisionService.saveDivision(any())).thenReturn(divisionDto.getDivision());
+        ErrorResponse expectedErrorResponse = new ErrorResponse(ApiErrorCode.INVALID_VALUE.name(), errorMsg);
+        ApiResponse<ErrorResponse> exepectedApiResponse = new ApiResponse<ErrorResponse>(false, expectedErrorResponse);
+        // when
+        // then
+        mockMvc.perform(post("/divisions")
+                .content(objectMapper.writeValueAsString(divisionDto))
+                .contentType(ContentType.APPLICATION_JSON.getMimeType()))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json(objectMapper.writeValueAsString(exepectedApiResponse)));
+    }
+
+    @Test
+    @DisplayName("부서명 수정 테스트(성공)")
+    @WithMockUser(authorities = "PRESIDENT")
+    void updateDivisionSuccessTest() throws Exception {
+        // given
+        DivisionDto divisionDto = new DivisionDto("TEST", "테스트 부서");
+        doNothing().when(divisionService).updateDivision(any());
+        // when
+        // then
+        mockMvc.perform(patch("/divisions")
+                .content(objectMapper.writeValueAsString(divisionDto))
+                .contentType(ContentType.APPLICATION_JSON.getMimeType()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("부서명 수정 테스트(실패-권한 문제)")
+    @WithMockUser(authorities = "VICE_PRESIDENT")
+    void updateDivisionFailForAuthorityTest() throws Exception {
+        // given
+        DivisionDto divisionDto = new DivisionDto("TEST", "테스트 부서");
+        doNothing().when(divisionService).updateDivision(any());
+        // when
+        // then
+        mockMvc.perform(patch("/divisions")
+                .content(objectMapper.writeValueAsString(divisionDto))
+                .contentType(ContentType.APPLICATION_JSON.getMimeType()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("부서명수정 테스트(실패-로그인하지 않은 사용자)")
+    @WithAnonymousUser
+    void updateDivisionFailForNoLogin() throws Exception {
+        // given
+        DivisionDto divisionDto = new DivisionDto("TEST", "테스트 부서");
+        doNothing().when(divisionService).updateDivision(any());
+        // when
+        // then
+        mockMvc.perform(patch("/divisions")
+                .content(objectMapper.writeValueAsString(divisionDto))
+                .contentType(ContentType.APPLICATION_JSON.getMimeType()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("부서명 삭제 테스트(성공)")
+    @WithMockUser(authorities = "PRESIDENT")
+    void deleteDivisionSuccessTest() throws Exception {
+        // given
+        DivisionDto divisionDto = new DivisionDto("TEST", "테스트 부서");
+        doNothing().when(divisionService).deleteDivision(any());
+        // when
+        // then
+        mockMvc.perform(patch("/divisions")
+                .content(objectMapper.writeValueAsString(divisionDto))
+                .contentType(ContentType.APPLICATION_JSON.getMimeType()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("부서명 삭제 테스트(실패-권한 문제)")
+    @WithMockUser(authorities = "VICE_PRESIDENT")
+    void deleteDivisionFailForAuthorityTest() throws Exception {
+        // given
+        DivisionDto divisionDto = new DivisionDto("TEST", "테스트 부서");
+        doNothing().when(divisionService).deleteDivision(any());
+        // when
+        // then
+        mockMvc.perform(patch("/divisions")
+                .content(objectMapper.writeValueAsString(divisionDto))
+                .contentType(ContentType.APPLICATION_JSON.getMimeType()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("부서명 삭제 테스트(실패-로그인하지 않은 사용자)")
+    @WithAnonymousUser
+    void deleteDivisionFailForNoLogin() throws Exception {
+        // given
+        DivisionDto divisionDto = new DivisionDto("TEST", "테스트 부서");
+        doNothing().when(divisionService).deleteDivision(any());
+        // when
+        // then
+        mockMvc.perform(patch("/divisions")
+                .content(objectMapper.writeValueAsString(divisionDto))
+                .contentType(ContentType.APPLICATION_JSON.getMimeType()))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/backend/src/test/java/com/inha/borrow/backend/controller/ItemControllerTest.java
+++ b/backend/src/test/java/com/inha/borrow/backend/controller/ItemControllerTest.java
@@ -1,4 +1,4 @@
-package com.inha.borrow.backend.controller.unit;
+package com.inha.borrow.backend.controller;
 
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.inha.borrow.backend.config.AuthConfig;
 import com.inha.borrow.backend.config.auth.admin.AdminAuthenticationProvider;
 import com.inha.borrow.backend.config.auth.borrowers.BorrowerAuthenticationProvider;
-import com.inha.borrow.backend.controller.ItemController;
 import com.inha.borrow.backend.enums.ItemState;
 import com.inha.borrow.backend.model.dto.item.ItemDeleteRequestDto;
 import com.inha.borrow.backend.model.dto.item.ItemDto;

--- a/backend/src/test/java/com/inha/borrow/backend/controller/SignUpRequestControllerTest.java
+++ b/backend/src/test/java/com/inha/borrow/backend/controller/SignUpRequestControllerTest.java
@@ -1,4 +1,4 @@
-package com.inha.borrow.backend.controller.unit;
+package com.inha.borrow.backend.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -36,7 +36,6 @@ import com.inha.borrow.backend.cache.IdCache;
 import com.inha.borrow.backend.config.AuthConfig;
 import com.inha.borrow.backend.config.auth.admin.AdminAuthenticationProvider;
 import com.inha.borrow.backend.config.auth.borrowers.BorrowerAuthenticationProvider;
-import com.inha.borrow.backend.controller.SignUpRequestController;
 import com.inha.borrow.backend.enums.ApiErrorCode;
 import com.inha.borrow.backend.enums.SignUpRequestState;
 import com.inha.borrow.backend.handler.GlobalErrorHandler;

--- a/backend/src/test/java/com/inha/borrow/backend/repository/DivisionRepositoryTest.java
+++ b/backend/src/test/java/com/inha/borrow/backend/repository/DivisionRepositoryTest.java
@@ -1,0 +1,116 @@
+package com.inha.borrow.backend.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.context.annotation.Import;
+
+import com.inha.borrow.backend.model.dto.division.DivisionDto;
+import com.inha.borrow.backend.model.entity.Division;
+import com.inha.borrow.backend.model.exception.InvalidValueException;
+import com.inha.borrow.backend.model.exception.ResourceNotFoundException;
+
+@JdbcTest
+@Import(DivisionRepository.class)
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public class DivisionRepositoryTest {
+    @Autowired
+    private DivisionRepository divisionRepository;
+
+    @Test
+    @DisplayName("Division 전체 목록 조회 테스트")
+    void findAllDivisionsTest() {
+        // given
+        DivisionDto testDivision = new DivisionDto("TEST", "테스트");
+        divisionRepository.saveDivision(testDivision);
+        // when
+        List<Division> result = divisionRepository.findAllDivisions();
+        // then
+        assertEquals(result.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Division 저장 테스트(성공)")
+    void saveDivisionSuccessTest() {
+        // given
+        DivisionDto testDivision = new DivisionDto("TEST", "테스트");
+        divisionRepository.saveDivision(testDivision);
+        // when
+        Division result = divisionRepository.findAllDivisions().get(0);
+        // then
+        assertEquals(result.getCode(), "TEST");
+        assertEquals(result.getName(), "테스트");
+    }
+
+    @Test
+    @DisplayName("Division 저장 테스트(실패-중복된 코드 값)")
+    void saveDivisionFailForDuplicatedCodeTest() {
+        // given
+        DivisionDto testDivision = new DivisionDto("TEST", "테스트");
+        divisionRepository.saveDivision(testDivision);
+        // when
+        // then
+        assertThrows(InvalidValueException.class, () -> {
+            divisionRepository.saveDivision(testDivision);
+        });
+    }
+
+    @Test
+    @DisplayName("Division 이름 수정 테스트(성공)")
+    void updateDivisionSuccessTest() {
+        // given
+        DivisionDto originDivision = new DivisionDto("TEST", "테스트");
+        DivisionDto revisedDivision = new DivisionDto("TEST", "변경된 부서명");
+        divisionRepository.saveDivision(originDivision);
+        // when
+        divisionRepository.updateDivision(revisedDivision);
+        Division result = divisionRepository.findAllDivisions().get(0);
+        // then
+        assertEquals(result.getName(), revisedDivision.getName());
+    }
+
+    @Test
+    @DisplayName("Division 이름 수정 테스트(실패-부서 미존재)")
+    void updateDivisionFailForNotExistTest() {
+        // given
+        DivisionDto divisionDto = new DivisionDto("TEST", "수정할거임");
+        // when
+        // then
+        assertThrows(ResourceNotFoundException.class, () -> {
+            divisionRepository.updateDivision(divisionDto);
+        });
+    }
+
+    @Test
+    @DisplayName("Division 이름 삭제 테스트(성공)")
+    void deleteDivisionSuccessTest() {
+        // given
+        DivisionDto divisionDto = new DivisionDto("TEST", "테스트");
+        divisionRepository.saveDivision(divisionDto);
+        // when
+        divisionRepository.deleteDivision(divisionDto);
+        List<Division> result = divisionRepository.findAllDivisions();
+        // then
+        assertEquals(result.size(), 0);
+    }
+
+    @Test
+    @DisplayName("Division 이름 삭제 테스트(실패-부서 미존재)")
+    void deleteDivisionFailForNotExistTest() {
+        // given
+        DivisionDto divisionDto = new DivisionDto("TEST", "수정할거임");
+        // when
+        // then
+        assertThrows(ResourceNotFoundException.class, () -> {
+            divisionRepository.deleteDivision(divisionDto);
+        });
+    }
+}

--- a/backend/src/test/java/com/inha/borrow/backend/service/DivisionServiceTest.java
+++ b/backend/src/test/java/com/inha/borrow/backend/service/DivisionServiceTest.java
@@ -1,0 +1,113 @@
+package com.inha.borrow.backend.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.inha.borrow.backend.model.dto.division.DivisionDto;
+import com.inha.borrow.backend.model.entity.Division;
+import com.inha.borrow.backend.model.exception.InvalidValueException;
+import com.inha.borrow.backend.model.exception.ResourceNotFoundException;
+
+@SpringBootTest
+@Transactional
+public class DivisionServiceTest {
+    @Autowired
+    private DivisionService divisionService;
+
+    @Test
+    @DisplayName("Division 전체 목록 조회 테스트")
+    void findAllDivisionsTest() {
+        // given
+        DivisionDto testDivision = new DivisionDto("TEST", "테스트");
+        divisionService.saveDivision(testDivision);
+        // when
+        List<Division> result = divisionService.findAllDivisions();
+        // then
+        assertEquals(result.size(), 1);
+    }
+
+    @Test
+    @DisplayName("Division 저장 테스트(성공)")
+    void saveDivisionSuccessTest() {
+        // given
+        DivisionDto testDivision = new DivisionDto("TEST", "테스트");
+        divisionService.saveDivision(testDivision);
+        // when
+        Division result = divisionService.findAllDivisions().get(0);
+        // then
+        assertEquals(result.getCode(), "TEST");
+        assertEquals(result.getName(), "테스트");
+    }
+
+    @Test
+    @DisplayName("Division 저장 테스트(실패-중복된 코드 값)")
+    void saveDivisionFailForDuplicatedCodeTest() {
+        // given
+        DivisionDto testDivision = new DivisionDto("TEST", "테스트");
+        divisionService.saveDivision(testDivision);
+        // when
+        // then
+        assertThrows(InvalidValueException.class, () -> {
+            divisionService.saveDivision(testDivision);
+        });
+    }
+
+    @Test
+    @DisplayName("Division 이름 수정 테스트(성공)")
+    void updateDivisionSuccessTest() {
+        // given
+        DivisionDto originDivision = new DivisionDto("TEST", "테스트");
+        DivisionDto revisedDivision = new DivisionDto("TEST", "변경된 부서명");
+        divisionService.saveDivision(originDivision);
+        // when
+        divisionService.updateDivision(revisedDivision);
+        Division result = divisionService.findAllDivisions().get(0);
+        // then
+        assertEquals(result.getName(), revisedDivision.getName());
+    }
+
+    @Test
+    @DisplayName("Division 이름 수정 테스트(실패-부서 미존재)")
+    void updateDivisionFailForNotExistTest() {
+        // given
+        DivisionDto divisionDto = new DivisionDto("TEST", "수정할거임");
+        // when
+        // then
+        assertThrows(ResourceNotFoundException.class, () -> {
+            divisionService.updateDivision(divisionDto);
+        });
+    }
+
+    @Test
+    @DisplayName("Division 이름 삭제 테스트(성공)")
+    void deleteDivisionSuccessTest() {
+        // given
+        DivisionDto divisionDto = new DivisionDto("TEST", "테스트");
+        divisionService.saveDivision(divisionDto);
+        // when
+        divisionService.deleteDivision(divisionDto);
+        List<Division> result = divisionService.findAllDivisions();
+        // then
+        assertEquals(result.size(), 0);
+    }
+
+    @Test
+    @DisplayName("Division 이름 삭제 테스트(실패-부서 미존재)")
+    void deleteDivisionFailForNotExistTest() {
+        // given
+        DivisionDto divisionDto = new DivisionDto("TEST", "수정할거임");
+        // when
+        // then
+        assertThrows(ResourceNotFoundException.class, () -> {
+            divisionService.deleteDivision(divisionDto);
+        });
+    }
+}


### PR DESCRIPTION
### 제작한 클래스
- Division : 부서정보를 담는 Entity
- DivisionDto : 컨트롤러에서 부서정보를 받는 클래스(생성, 수정, 삭제, 조회에 모두 쓰임)
- DivisionController, DivisionService, DivisionRepository : 전체조회, 생성, 수정, 삭제 기능

### /divisions 경로에 대한 접근제한은 아래와 같음
- GET : 국장(DIVISION_HEAD)이상만 접근가능
- POST, PATCH, DELETE : 학생회장만 접근가능

근데 만들고 나서 생각해보니까 부서 수정, 삭제 경로는 부서코드를 경로에 넣을걸 그랬네.. 
